### PR TITLE
App.js in the template generator shall not be minified

### DIFF
--- a/template/frontend/src/App.js
+++ b/template/frontend/src/App.js
@@ -1,1 +1,11 @@
-import React from 'react';\n\nfunction App() {\n  return (\n    <div className="App">\n      <h1>Welcome to MERN Project</h1>\n    </div>\n  );\n}\n\nexport default App;
+import React from 'react';
+
+function App() {
+  return (
+    <div className="App">
+      <h1>Welcome to MERN Project</h1>
+    </div>
+  );
+}
+
+export default App;


### PR DESCRIPTION
This PR deminifies App.js in the template generator. The minified version was unnecessary and just makes things harder to read, considering that people want to use this as an editable template.