### PR TITLE
feat(cli): initialize react native project with NativeWind preconfigured

### DIFF
--- a/commands/initReactNative.js
+++ b/commands/initReactNative.js
@@ -1,0 +1,122 @@
+import path from 'path';
+import fs from 'fs';
+import { execSync } from 'child_process';
+import chalk from 'chalk';
+import { checkNodeVersion } from '../utils/checkNodeVersion.js';
+import { taskHandler } from '../utils/taskHandler.js';
+import {
+  tailwindConfig,
+  globalCss,
+  babelConfig,
+  metroConfig,
+  layoutFile,
+  indexFile,
+  appJson,
+} from '../utils/config.js';
+
+function createExpoReactNative(projectName) {
+  checkNodeVersion();
+
+  let rootDir = '';
+  if (projectName === '.') rootDir = process.cwd();
+  else rootDir = path.join(process.cwd(), projectName);
+
+  // Initializing Expo Project
+  taskHandler(
+    () => {
+      execSync(`npx create-expo-app@latest ${projectName}`, {
+        stdio: 'inherit',
+      });
+    },
+    '🔧 Initiating Expo project...',
+    '✅ Initialized Expo project successfully!',
+    '❌ Error while initializing an Expo project'
+  );
+
+  // Run Expo Reset Script
+  taskHandler(
+    () => {
+      execSync(`npm run reset-project`, {
+        stdio: ['pipe', 'inherit', 'inherit'],
+        input: 'Y\n',
+        cwd: rootDir,
+      });
+    },
+    '🔧 Resetting Expo project...',
+    '✅ Reset Expo project successfully!',
+    '❌ Error while resetting an Expo project'
+  );
+
+  // Installing NativeWind dependencies
+  taskHandler(
+    () =>
+      execSync(
+        'npm install nativewind react-native-reanimated@~3.17.4 react-native-safe-area-context@5.4.0',
+        { stdio: 'inherit', cwd: rootDir }
+      ),
+    '🔧 Installing NativeWind dependencies...',
+    '✅ NativeWind dependencies installed successfully!',
+    '❌ Error while installing NativeWind dependencies'
+  );
+
+  // Installing dev dependencies
+  taskHandler(
+    () =>
+      execSync(
+        'npm install --dev tailwindcss@^3.4.17 prettier-plugin-tailwindcss@^0.5.11',
+        { stdio: 'inherit', cwd: rootDir }
+      ),
+    '🔧 Installing dev dependencies...',
+    '✅ dev dependencies installed successfully!',
+    '❌ Error while installing dev dependencies'
+  );
+
+  // Initializing tailwind config file
+  taskHandler(
+    () => execSync('npx tailwindcss init', { stdio: 'inherit', cwd: rootDir }),
+    '🔧 Installing dev dependencies...',
+    '✅ dev dependencies installed successfully!',
+    '❌ Error while installing dev dependencies'
+  );
+
+  taskHandler(() => {
+    fs.writeFileSync(path.join(rootDir, 'tailwind.config.js'), tailwindConfig),
+      fs.writeFileSync(path.join(rootDir, './app/global.css'), globalCss),
+      fs.writeFileSync(path.join(rootDir, 'babel.config.js'), babelConfig),
+      fs.writeFileSync(path.join(rootDir, 'metro.config.js'), metroConfig),
+      fs.writeFileSync(path.join(rootDir, './app/_layout.tsx'), layoutFile),
+      fs.writeFileSync(path.join(rootDir, './app/index.tsx'), indexFile),
+      fs.writeFileSync(path.join(rootDir, 'app.json'), appJson),
+      '✍️ Adding files to setup NativeWind...',
+      '✅ All files written successfully!',
+      '❌ Failed to write some or all files';
+  });
+
+  taskHandler(
+    () => execSync('git init', { cwd: rootDir }),
+    '🔧 Initiating Git repo...',
+    '✅ Initialized Git repo successfully!',
+    '❌ Error while initializing a Git repo'
+  );
+
+  console.log(
+    '-------------------------------------------------------------------------'
+  );
+  console.log(
+    chalk.blue(
+      '🚀React Native + NativeWind project initialized with all basic configurations successfully!'
+    )
+  );
+  console.log(
+    '-------------------------------------------------------------------------'
+  );
+}
+
+export default function initReactNative(program) {
+  program
+    .command('create-react-native <projectName>')
+    .description('Create a new Expo React Native project')
+    .action((projectName) => {
+      createExpoReactNative(projectName);
+    });
+}

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ import initializeDockerCommand from './commands/initializeDocker.js';
 import addESLintCommand from './commands/addESLint.js';
 import addJWTAuthCommand from './commands/addJWTAuth.js';
 import addDeployCommand from './commands/deployCommand.js';
+import initReactNative from './commands/initReactNative.js';
 
 // Step 1: Get the directory of the current file
 const __filename = fileURLToPath(import.meta.url);
@@ -45,6 +46,7 @@ initializeDockerCommand(program);
 addESLintCommand(program);
 addJWTAuthCommand(program);
 addDeployCommand(program);
+initReactNative(program);
 
 // Step 5: Parse the provided arguments and start the CLI
 program.parse(process.argv);

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,0 +1,104 @@
+export const tailwindConfig = `/** @type {import('tailwindcss').Config} */
+  module.exports = {
+    // NOTE: Update this to include the paths to all files that contain Nativewind classes.
+    content: ["./App.tsx", "./components/**/*.{js,jsx,ts,tsx}", "./app/**/*.{js,jsx,ts,tsx}"],
+    presets: [require("nativewind/preset")],
+    theme: {
+      extend: {},
+    },
+    plugins: [],
+}`;
+
+export const globalCss = `@tailwind base;
+@tailwind components;
+@tailwind utilities;`;
+
+export const babelConfig = `module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: [
+      ["babel-preset-expo", { jsxImportSource: "nativewind" }],
+      "nativewind/babel",
+    ],
+  };
+};`;
+
+export const metroConfig = `const { getDefaultConfig } = require("expo/metro-config");
+const { withNativeWind } = require('nativewind/metro');
+ 
+const config = getDefaultConfig(__dirname)
+ 
+module.exports = withNativeWind(config, { input: './app/global.css' })`;
+
+export const layoutFile = `import { Stack } from "expo-router";
+import "./global.css"
+
+export default function RootLayout() {
+  return <Stack />;
+}`;
+
+export const indexFile = `import { Text, View } from "react-native";
+
+export default function Index() {
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Text>Decli successfully initialized your app!.</Text>
+    </View>
+  );
+}`;
+
+export const appJson = `{
+  "expo": {
+    "name": "TESTING",
+    "slug": "TESTING",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/images/icon.png",
+    "scheme": "testing",
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": true,
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#E6F4FE",
+        "foregroundImage": "./assets/images/android-icon-foreground.png",
+        "backgroundImage": "./assets/images/android-icon-background.png",
+        "monochromeImage": "./assets/images/android-icon-monochrome.png"
+      },
+      "edgeToEdgeEnabled": true,
+      "predictiveBackGestureEnabled": false
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "static",
+      "favicon": "./assets/images/favicon.png"
+    },
+    "plugins": [
+      "expo-router",
+      [
+        "expo-splash-screen",
+        {
+          "image": "./assets/images/splash-icon.png",
+          "imageWidth": 200,
+          "resizeMode": "contain",
+          "backgroundColor": "#ffffff",
+          "dark": {
+            "backgroundColor": "#000000"
+          }
+        }
+      ]
+    ],
+    "experiments": {
+      "typedRoutes": true,
+      "reactCompiler": true
+    }
+  }
+}`;


### PR DESCRIPTION
## *feat: Add 'create-react-native' command for React Native + NativeWind scaffolding*

#### TL;DR - adds a new command to initialize a react native (expo) project with NativeWind preconfigured and ready to go🚀  
---
### Description
<!-- Provide a concise description of your changes. Explain the purpose and include any relevant context. -->

This pull request introduces a new command, `create-react-native`, to the CLI. This feature addresses the request for a streamlined way to set up a React Native project with modern tooling i.e. NativeWind. It allows users to scaffold a new project using **Expo**, pre-configured with **NativeWind**, enabling the use of Tailwind CSS classes directly in their React Native components.

The entire setup process is automated, from project initialization to dependency installation and configuration file generation.

### **Steps to run:**

1. Run the new command to create a test project:
	`devcli create-react-native MyTestApp`

2. Navigate into the new project directory:
	`cd MyTestApp`

3. Start the Expo development server:
	`npx expo start`

4. Open the app in an emulator or on a physical device using the ExpoGo app. The app should build and run without any errors, and the default screen should display content styled with Tailwind CSS classes.
   [Expo docs](https://docs.expo.dev/get-started/set-up-your-environment/)



### Related Issue(s)
<!-- Link any related issues (use #issue_number). Example: Resolves #45 -->
Resolves #27 

---
### Changes Made.
- [ x ] Added a new feature
- [ ] Fixed a bug
- [ x ] Refactored existing code
- [ ] Updated documentation
- [ ] Other (explain):

List and describe the main changes here:
### **Detailed Changes**

1. **New Command: `create-react-native <projectName>`**
    
    - A new command is registered to handle the scaffolding process. It can be invoked via `create-react-native MyTestApp`.
    
2. New File: ***initReactNative.js***
    
    - This file contains the core logic for the new command. The workflow is as follows:
        - Initializes a new Expo project using `npx create-expo-app`.
        - Resets the expo project for a minimal configuration.
        - Installs necessary dependencies for NativeWind, including `nativewind`, `react-native-reanimated`, and `react-native-safe-area-context`.
        - Installs required dev dependencies like `tailwindcss`.
        - Runs `npx tailwindcss init` to generate a base config file.
        - Overwrites and creates several configuration files with project-specific templates to correctly set up NativeWind.
        - Initializes the project as a git repository with `git init` command.
        
3. New File: ***config.js***
    
    - To maintain clean and readable command logic, all configuration file templates have been centralized in this new utility file. This includes the content for:
        - `tailwind.config.js` (basic tailwind config).
        - `global.css` (adds the tailwind imports).
        - `babel.config.js` (includes the `nativewind/babel` plugin).
        - `metro.config.js` (wrapped with `withNativeWind`).
        -  `_layout.tsx` (import the global styles so tailwind classes can be used anywhere in the project) .
        - `index.tsx` (write a custom Devcli welcome page).
        - `app.json` (adds required *metro* web bundler setting).
        
4. Modified File: ***index.js***
    
    - The main entry point of the CLI has been updated to import and register the new `initReactNative` command, making it available to the user.
---
### Checklist
Please ensure the following have been completed:
If yes, do [x].
- [ x ] Code compiles without errors
- [ x ] Tests are written and passing (if applicable)
- [ ] Documentation is updated (in code or README as needed)
- [ x ] Code adheres to style guidelines (Prettier, ESLint)

### Dependencies
<!-- List any new dependencies introduced or any updates to existing dependencies -->
_NIL_

### Additional Notes
<!-- Add any additional comments, warnings, or suggestions related to this PR -->
Readme needs to be updated with the new command!
